### PR TITLE
Upload - add shared drive support

### DIFF
--- a/Frends.GoogleDrive.Upload/CHANGELOG.md
+++ b/Frends.GoogleDrive.Upload/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## [1.1.0]
+### Added
+- Added a flag for shared drive support in the file search
+
 ## [1.0.1] - 2023-12-07
 ### Changed
 - Input.ServiceAccountKeyJSON and Result.ErrorMessage documentation update.

--- a/Frends.GoogleDrive.Upload/Frends.GoogleDrive.Upload/Definitions/Input.cs
+++ b/Frends.GoogleDrive.Upload/Frends.GoogleDrive.Upload/Definitions/Input.cs
@@ -55,4 +55,11 @@ public class Input
     [DisplayFormat(DataFormatString = "Text")]
     [PasswordPropertyText]
     public string ServiceAccountKeyJSON { get; set; }
+
+    /// <summary>
+    /// Whether to enable support for shared drives.
+    /// </summary>
+    /// <example>false</example>
+    [DefaultValue(false)]
+    public bool IncludeSharedDrives { get; set; }
 }

--- a/Frends.GoogleDrive.Upload/Frends.GoogleDrive.Upload/Frends.GoogleDrive.Upload.cs
+++ b/Frends.GoogleDrive.Upload/Frends.GoogleDrive.Upload/Frends.GoogleDrive.Upload.cs
@@ -51,7 +51,7 @@ public class GoogleDrive
                 {
                     request = service.Files.Create(fileMetadata, stream, null);
                     request.Fields = "id";
-                    request.SupportsAllDrives = true;
+                    request.SupportsAllDrives = input.IncludeSharedDrives;
 
                     var results = await request.UploadAsync(cancellationToken);
 

--- a/Frends.GoogleDrive.Upload/Frends.GoogleDrive.Upload/Frends.GoogleDrive.Upload.csproj
+++ b/Frends.GoogleDrive.Upload/Frends.GoogleDrive.Upload/Frends.GoogleDrive.Upload.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.0.1</Version>
+	<Version>1.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
#14 

The task actually already had the shared drive support enabled (fileListRequest.SupportsAllDrives = true), but added the input flag anyway to make it optional, so that it's in line with the other tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for shared drives in file searches with a new property `IncludeSharedDrives`.
	- Enhanced upload functionality to conditionally support shared drives based on user input.

- **Documentation**
	- Updated documentation for parameters `Input.ServiceAccountKeyJSON` and `Result.ErrorMessage` for clarity.

- **Version Update**
	- Incremented version number from 1.0.1 to 1.1.0, reflecting new features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->